### PR TITLE
refactor: decoupling the search for authors from the book mapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
 			<artifactId>h2</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>3.1.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/dev/nicacio/exchbook/dtos/request/CreateBookRequestDto.java
+++ b/src/main/java/dev/nicacio/exchbook/dtos/request/CreateBookRequestDto.java
@@ -1,5 +1,15 @@
 package dev.nicacio.exchbook.dtos.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
 import java.util.List;
 
-public record CreateBookRequestDto(String title,List<Integer> authorIds ) { }
+public record CreateBookRequestDto(
+        @NotBlank(message = "Title is required")
+        String title,
+
+        @NotEmpty(message ="At least one Id must be passed")
+        @NotNull(message = "Author Id cannot be null")
+        List<Integer> authorIds ) { }

--- a/src/main/java/dev/nicacio/exchbook/mapper/BookMapper.java
+++ b/src/main/java/dev/nicacio/exchbook/mapper/BookMapper.java
@@ -14,15 +14,7 @@ import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface BookMapper {
-    @Mapping(target = "authors", source = "authorIds")
-    Book toBook (CreateBookRequestDto createBook, @Context AuthorRepository authorRepository);
-
-    default List<Author> mapAuthorsIdsToAuthors(List<Integer> authorIds, @Context AuthorRepository authorRepository){
-      List<Author> authors =authorIds != null ? authorRepository.findAllById(authorIds): Collections.emptyList();
-      if(authors.isEmpty()){
-          throw new IllegalArgumentException("No Author found, can't create a book");
-      }
-      return authors;
-    }
+    //@Mapping(target = "authors", source = "authorIds")
+    Book toBook (CreateBookRequestDto createBook, List<Author> authors);
     BookDto toBookDto(Book book);
 }

--- a/src/main/java/dev/nicacio/exchbook/services/BookService.java
+++ b/src/main/java/dev/nicacio/exchbook/services/BookService.java
@@ -26,7 +26,13 @@ public class BookService {
     private final BookMapper bookMapper;
 
         public int registerBook(CreateBookRequestDto createBookDto){
-            Book book = bookMapper.toBook(createBookDto,authorRepository);
+            List<Author> authors = authorRepository.findAllById(createBookDto.authorIds());
+
+            if(authors.isEmpty()){
+                throw new ResourceNotFoundException("Author(s) not found");
+            }
+
+            Book book = bookMapper.toBook(createBookDto,authors);
             Book savedBook = bookRepository.save(book);
             return savedBook.getIdBook();
         }


### PR DESCRIPTION
Book Mapper had two responsabilities, to search for the authors of the book and to map DTO for the Book Entity, wich violated the principle of single responsability.