### PR TITLE
Feature/update book by

### DIFF
--- a/src/main/java/dev/nicacio/exchbook/mapper/AuthorMapper.java
+++ b/src/main/java/dev/nicacio/exchbook/mapper/AuthorMapper.java
@@ -4,8 +4,10 @@ import dev.nicacio.exchbook.dtos.request.CreateAuthorRequestDto;
 import dev.nicacio.exchbook.dtos.request.UpdateAuthorRequestDto;
 import dev.nicacio.exchbook.dtos.response.AuthorDto;
 import dev.nicacio.exchbook.models.Author;
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.mapstruct.factory.Mappers;
 import org.springframework.context.annotation.Bean;
 
@@ -13,5 +15,6 @@ import org.springframework.context.annotation.Bean;
 public interface AuthorMapper {
     Author toAuthor(CreateAuthorRequestDto requestDto);
     AuthorDto toAuthorDto(Author author);
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     void updateAuthorFromDto(UpdateAuthorRequestDto update, @MappingTarget Author author);
 }

--- a/src/main/java/dev/nicacio/exchbook/mapper/BookEditionMapper.java
+++ b/src/main/java/dev/nicacio/exchbook/mapper/BookEditionMapper.java
@@ -6,10 +6,7 @@ import dev.nicacio.exchbook.dtos.response.BookEditionDto;
 import dev.nicacio.exchbook.models.Book;
 import dev.nicacio.exchbook.models.BookEdition;
 import dev.nicacio.exchbook.repository.BookRepository;
-import org.mapstruct.Context;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
+import org.mapstruct.*;
 
 import java.util.Optional;
 
@@ -18,5 +15,6 @@ public interface BookEditionMapper {
     @Mapping(target = "book", source = "book")
     BookEdition toBookEdition(CreateBookEditionRequestDto createBookEdition,Book book);
     BookEditionDto toBookEditionDto (BookEdition bookEdition);
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     void updateBookEditionFromDto(UpdateEditionRequestDto updateDto,@MappingTarget BookEdition bookEdition);
 }

--- a/src/main/java/dev/nicacio/exchbook/mapper/BookMapper.java
+++ b/src/main/java/dev/nicacio/exchbook/mapper/BookMapper.java
@@ -1,13 +1,14 @@
 package dev.nicacio.exchbook.mapper;
 
 import dev.nicacio.exchbook.dtos.request.CreateBookRequestDto;
+import dev.nicacio.exchbook.dtos.request.UpdateBookRequestDto;
 import dev.nicacio.exchbook.dtos.response.BookDto;
 import dev.nicacio.exchbook.models.Author;
 import dev.nicacio.exchbook.models.Book;
+import dev.nicacio.exchbook.models.BookCopy;
 import dev.nicacio.exchbook.repository.AuthorRepository;
-import org.mapstruct.Context;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+import org.mapstruct.*;
+import org.springframework.context.annotation.Bean;
 
 import java.util.Collections;
 import java.util.List;
@@ -17,4 +18,6 @@ public interface BookMapper {
     //@Mapping(target = "authors", source = "authorIds")
     Book toBook (CreateBookRequestDto createBook, List<Author> authors);
     BookDto toBookDto(Book book);
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateBookFromDto(UpdateBookRequestDto updateDto, @MappingTarget Book book);
 }

--- a/src/main/java/dev/nicacio/exchbook/services/BookService.java
+++ b/src/main/java/dev/nicacio/exchbook/services/BookService.java
@@ -50,7 +50,7 @@ public class BookService {
         public void updateBook(int idBook, UpdateBookRequestDto updateBook){
             Book book = bookRepository.findById(idBook)
                     .orElseThrow(()-> new ResourceNotFoundException("Book not found"));
-            book.setTitle(updateBook.title());
+            bookMapper.updateBookFromDto(updateBook,book);
             bookRepository.save(book);
         }
     }

--- a/src/test/java/dev/nicacio/exchbook/services/BookServiceTest.java
+++ b/src/test/java/dev/nicacio/exchbook/services/BookServiceTest.java
@@ -152,19 +152,18 @@ class BookServiceTest {
         int idBook = 1;
         UpdateBookRequestDto requestDto = new UpdateBookRequestDto("New Title");
 
-        Optional<Book> savedBook = Optional.of(new Book());
-        savedBook.get().setIdBook(1);
-        savedBook.get().setTitle("Current Title");
+        Book savedBook = new Book();
+        savedBook.setIdBook(1);
+        savedBook.setTitle("Current Title");
 
-        when(bookRepository.findById(1)).thenReturn(savedBook);
-        when(bookRepository.save(any(Book.class))).thenReturn(savedBook.get());
+        when(bookRepository.findById(1)).thenReturn(Optional.of(savedBook));
+        when(bookRepository.save(any(Book.class))).thenReturn(savedBook);
 
         bookService.updateBook(idBook,requestDto);
 
+        verify(bookMapper,times(1)).updateBookFromDto(requestDto,savedBook);
         verify(bookRepository,times(1)).findById(any());
         verify(bookRepository,times(1)).save(any(Book.class));
-
-        assertEquals(requestDto.title(),savedBook.get().getTitle());
 
     }
 }


### PR DESCRIPTION
I've improved the mapping of UpdateDto, being done in BookMapper, so that even if the Entity has more fields to update, the updateBook method won't need to grow.

The second commit refers to a  line that was missing from the previous commits. The code in question ensures that null fields in the Dto do not overwrite existing values in the Entity.